### PR TITLE
Compat with libqi-2.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(catkin REQUIRED naoqi_libqi)
 find_package(Boost)
 
 catkin_package(LIBRARIES qicore
-  INCLUDE ./
+  INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/libqicore/
   DEPENDS Boost
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,14 @@
 ## Copyright (c) 2012 Aldebaran Robotics. All rights reserved.
 
 cmake_minimum_required(VERSION 2.8)
-project(naoqi_libqicore)
-find_package(catkin REQUIRED naoqi_libqi)
-find_package(Boost)
-
-catkin_package(LIBRARIES qicore
-  INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/libqicore/
-  DEPENDS Boost
-)
+project(LibQiCore)
+find_package(qibuild)
+qi_sanitize_compile_flags(HIDDEN_SYMBOLS)
 
 # Tests
 enable_testing()
 
 add_subdirectory("libqicore")
-#add_subdirectory("services")
-#add_subdirectory("bin")
+add_subdirectory("services")
+add_subdirectory("bin")
 
-# Install catkin package.xml
-install(FILES package.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(naoqi_libqicore)
 find_package(catkin REQUIRED naoqi_libqi)
 find_package(Boost)
 
+add_definitions(-std=gnu++11)
+
 catkin_package(LIBRARIES qicore
   INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/libqicore/
   DEPENDS Boost

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,21 @@
 ## Copyright (c) 2012 Aldebaran Robotics. All rights reserved.
 
 cmake_minimum_required(VERSION 2.8)
-project(LibQiCore)
-find_package(qibuild)
-qi_sanitize_compile_flags(HIDDEN_SYMBOLS)
+project(naoqi_libqicore)
+find_package(catkin REQUIRED naoqi_libqi)
+find_package(Boost)
+
+catkin_package(LIBRARIES qicore
+  INCLUDE ./
+  DEPENDS Boost
+)
 
 # Tests
 enable_testing()
 
 add_subdirectory("libqicore")
-add_subdirectory("services")
-add_subdirectory("bin")
+#add_subdirectory("services")
+#add_subdirectory("bin")
 
+# Install catkin package.xml
+install(FILES package.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/libqicore/CMakeLists.txt
+++ b/libqicore/CMakeLists.txt
@@ -1,6 +1,7 @@
 ## Copyright (c) 2012, 2014 Aldebaran Robotics. All rights reserved.
 
-include_directories("." ${catkin_INCLUDE_DIRS})
+find_package(qimodule)
+include_directories(".")
 
 set(PUBLIC_HEADERS
     qicore/api.hpp
@@ -10,19 +11,20 @@ set(PUBLIC_HEADERS
     qicore/logmessage.hpp
     qicore/logprovider.hpp
     )
-install(FILES ${PUBLIC_HEADERS} DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/qicore)
+qi_install_header(${PUBLIC_HEADERS})
 
-add_library(qicore
+qi_create_module(qicore SRC
   ${PUBLIC_HEADERS}
   #src/behavior.cpp src/behaviormodel.cpp src/format_behavior_model.cpp
   src/loglistener_proxy.cpp
   src/logmanager_proxy.cpp
   src/logprovider_proxy.cpp
+  src/registration.cpp
   src/logproviderimpl.cpp
   src/logproviderimpl.hpp
+  DEPENDS BOOST
 )
+qi_use_lib(qicore QI)
+qi_stage_lib(qicore)
 
-target_link_libraries(qicore ${Boost_LIBRARIES} ${catkin_LIBRARIES})
-install(TARGETS qicore DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
-
-#add_subdirectory("tests")
+add_subdirectory("tests")

--- a/libqicore/CMakeLists.txt
+++ b/libqicore/CMakeLists.txt
@@ -1,6 +1,5 @@
 ## Copyright (c) 2012, 2014 Aldebaran Robotics. All rights reserved.
 
-find_package(qimodule)
 include_directories(".")
 
 set(PUBLIC_HEADERS
@@ -11,20 +10,19 @@ set(PUBLIC_HEADERS
     qicore/logmessage.hpp
     qicore/logprovider.hpp
     )
-qi_install_header(${PUBLIC_HEADERS})
+install(FILES ${PUBLIC_HEADERS} DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/qicore)
 
-qi_create_module(qicore SRC
+add_library(qicore
   ${PUBLIC_HEADERS}
   #src/behavior.cpp src/behaviormodel.cpp src/format_behavior_model.cpp
   src/loglistener_proxy.cpp
   src/logmanager_proxy.cpp
   src/logprovider_proxy.cpp
-  src/registration.cpp
   src/logproviderimpl.cpp
   src/logproviderimpl.hpp
-  DEPENDS BOOST
 )
-qi_use_lib(qicore QI)
-qi_stage_lib(qicore)
 
-add_subdirectory("tests")
+target_link_libraries(qicore ${Boost_LIBRARIES} ${catkin_LIBRARIES})
+install(TARGETS qicore DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+
+#add_subdirectory("tests")

--- a/libqicore/CMakeLists.txt
+++ b/libqicore/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## Copyright (c) 2012, 2014 Aldebaran Robotics. All rights reserved.
 
-include_directories(".")
+include_directories("." ${catkin_INCLUDE_DIRS})
 
 set(PUBLIC_HEADERS
     qicore/api.hpp

--- a/libqicore/qicore/logmessage.hpp
+++ b/libqicore/qicore/logmessage.hpp
@@ -12,7 +12,7 @@
 # include <qi/log.hpp>
 # include <qi/anyobject.hpp>
 
-QI_TYPE_ENUM_REGISTER(qi::LogLevel)
+QI_TYPE_ENUM(qi::LogLevel)
 
 namespace qi
 {


### PR DESCRIPTION
This is necessary to have `libqicore` to play nicely with `libqi-2.5` as imported in ros-naoqi/libqi-release#1
